### PR TITLE
Parametrize GeometryDeserializer for supported subtypes and allow custom GeometryFactory

### DIFF
--- a/src/main/java/com/bedatadriven/jackson/datatype/jts/GeometryDeserializer.java
+++ b/src/main/java/com/bedatadriven/jackson/datatype/jts/GeometryDeserializer.java
@@ -12,7 +12,7 @@ import java.io.IOException;
 
 import static com.bedatadriven.jackson.datatype.jts.GeoJson.*;
 
-public class GeometryDeserializer extends JsonDeserializer<Geometry> {
+public class GeometryDeserializer <T extends Geometry> extends JsonDeserializer<T> {
 
 	private GeometryFactory gf;
 
@@ -29,35 +29,36 @@ public class GeometryDeserializer extends JsonDeserializer<Geometry> {
 	}
 
 	@Override
-	public Geometry deserialize(JsonParser jp, DeserializationContext ctxt)
+	public T deserialize(JsonParser jp, DeserializationContext ctxt)
 			throws IOException {
 		ObjectCodec oc = jp.getCodec();
 		JsonNode root = oc.readTree(jp);
 		return parseGeometry(root);
 	}
 
-	private Geometry parseGeometry(JsonNode root) throws JsonMappingException {
+	@SuppressWarnings("unchecked")
+	private T parseGeometry(JsonNode root) throws JsonMappingException {
 		String typeName = root.get(TYPE).asText();
 		if (POINT.equals(typeName)) {
-			return parsePoint(root);
+			return (T) parsePoint(root);
 
 		} else if(MULTI_POINT.equals(typeName)) {
-			return parseMultiPoint(root);
+			return (T) parseMultiPoint(root);
 
 		} else if(LINE_STRING.equals(typeName)) {
-			return parseLineString(root);
+			return (T) parseLineString(root);
 
 		} else if (MULTI_LINE_STRING.equals(typeName)) {
-			return parseMultiLineStrings(root);
+			return (T) parseMultiLineStrings(root);
 
 		} else if(POLYGON.equals(typeName)) {
-			return parsePolygon(root);
+			return (T) parsePolygon(root);
 
 		} else if (MULTI_POLYGON.equals(typeName)) {
-			return parseMultiPolygon(root);
+			return (T) parseMultiPolygon(root);
 
 		} else if (GEOMETRY_COLLECTION.equals(typeName)) {
-			return parseGeometryCollection(root);
+			return (T) parseGeometryCollection(root);
 
 		} else {
 			throw new JsonMappingException("Invalid geometry type: " + typeName);

--- a/src/main/java/com/bedatadriven/jackson/datatype/jts/JtsModule.java
+++ b/src/main/java/com/bedatadriven/jackson/datatype/jts/JtsModule.java
@@ -3,18 +3,36 @@ package com.bedatadriven.jackson.datatype.jts;
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.GeometryCollection;
 import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.LineString;
+import com.vividsolutions.jts.geom.MultiLineString;
+import com.vividsolutions.jts.geom.MultiPoint;
+import com.vividsolutions.jts.geom.MultiPolygon;
+import com.vividsolutions.jts.geom.Point;
+import com.vividsolutions.jts.geom.Polygon;
 
 public class JtsModule extends SimpleModule {
+	private static final long serialVersionUID = -6046431936495229027L;
 
 	public JtsModule() {
 		this(null);
 	}
 
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public JtsModule(GeometryFactory factory) {
 		super("JtsModule", new Version(1, 0, 0, null,"com.bedatadriven","jackson-datatype-jts"));
 
 		addSerializer(Geometry.class, new GeometrySerializer());
-		addDeserializer(Geometry.class, new GeometryDeserializer(factory));
+		GeometryDeserializer deser = new GeometryDeserializer();
+		addDeserializer(Geometry.class, deser);
+		addDeserializer(GeometryCollection.class, deser);
+		addDeserializer(Point.class, deser);
+		addDeserializer(MultiPoint.class, deser);
+		addDeserializer(LineString.class, deser);
+		addDeserializer(MultiLineString.class, deser);
+		addDeserializer(MultiPolygon.class, deser);
+		addDeserializer(Polygon.class, deser);
+		addDeserializer(GeometryCollection.class, deser);
 	}
 }

--- a/src/test/java/com/bedatadriven/jackson/datatype/jts/JtsModuleTest.java
+++ b/src/test/java/com/bedatadriven/jackson/datatype/jts/JtsModuleTest.java
@@ -30,6 +30,7 @@ public class JtsModuleTest {
 	@Test
 	public void point() throws Exception {
 		Point point = gf.createPoint(new Coordinate(1.2345678, 2.3456789));
+		
 		assertRoundTrip(point);
 		assertThat(
 				toJson(point),
@@ -153,7 +154,7 @@ public class JtsModuleTest {
 	private void assertRoundTrip(Geometry geom) throws IOException {
 		String json = writer.writeValueAsString(geom);
 		System.out.println(json);
-		Geometry regeom = mapper.reader(Geometry.class).readValue(json);
+		Geometry regeom = mapper.readValue(json, geom.getClass());
 		assertThat(regeom, equalTo(geom));
 	}
 }


### PR DESCRIPTION
So I am building on vkasala/jackson-datatype-jts by permitting deserialization of Geometry subtypes. Until now, Jackson had no idea that JtsModule should be used to deserialize Point or Polygon objects, since only Geometry was registered, and it would crash on attempt since these classes don't have default constructors.

Tests pass, I also edited the assertRoundTrip to test this new functionality